### PR TITLE
Update to 20.08 runtime

### DIFF
--- a/com.retrodev.blastem.json
+++ b/com.retrodev.blastem.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.retrodev.blastem",
     "runtime" : "org.freedesktop.Platform",
-    "runtime-version" : "20.08",
+    "runtime-version" : "21.08",
     "sdk" : "org.freedesktop.Sdk",
     "command" : "blastem",
     "finish-args" : [

--- a/com.retrodev.blastem.json
+++ b/com.retrodev.blastem.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.retrodev.blastem",
     "runtime" : "org.freedesktop.Platform",
-    "runtime-version" : "18.08",
+    "runtime-version" : "20.08",
     "sdk" : "org.freedesktop.Sdk",
     "command" : "blastem",
     "finish-args" : [
@@ -16,7 +16,7 @@
         "--filesystem=xdg-run/gvfs:ro"
     ],
     "modules" : [
-        "shared-modules/glu/glu-9.0.0.json",
+        "shared-modules/glu/glu-9.json",
         "shared-modules/glew/glew.json",
         {
             "name" : "blastem",
@@ -48,7 +48,10 @@
                 },
                 {
                     "type" : "patch",
-                    "path" : "0001-Add-support-for-Flatpak-config-data-dir-variables.patch"
+                    "paths" : [
+                        "0001-Add-support-for-Flatpak-config-data-dir-variables.patch",
+                        "fix-multiple-definition-errors.patch"
+                    ]
                 },
                 {
                     "type" : "file",

--- a/fix-multiple-definition-errors.patch
+++ b/fix-multiple-definition-errors.patch
@@ -1,0 +1,71 @@
+
+# HG changeset patch
+# User Mike Pavone <pavone@retrodev.com>
+# Date 1594527392 25200
+# Node ID e45a317802bdcdbf259d9daf0620059a93a15251
+# Parent  7a6835c02db0cd78fcbf0d315a4705919b922c0f
+Fix broken enum definitions that cause multiple definition errors when building with -fno-common which is now the default in GCC 10
+
+diff -r 7a6835c02db0 -r e45a317802bd gen_x86.c
+--- a/gen_x86.c	Sat Jul 11 21:04:16 2020 -0700
++++ b/gen_x86.c	Sat Jul 11 21:16:32 2020 -0700
+@@ -130,7 +130,7 @@
+ 	X86_R13,
+ 	X86_R14,
+ 	X86_R15
+-} x86_regs_enc;
++};
+ 
+ char * x86_reg_names[] = {
+ #ifdef X86_64
+diff -r 7a6835c02db0 -r e45a317802bd gen_x86.h
+--- a/gen_x86.h	Sat Jul 11 21:04:16 2020 -0700
++++ b/gen_x86.h	Sat Jul 11 21:16:32 2020 -0700
+@@ -30,7 +30,7 @@
+ 	R13,
+ 	R14,
+ 	R15
+-} x86_regs;
++};
+ 
+ enum {
+ 	CC_O = 0,
+@@ -51,14 +51,14 @@
+ 	CC_GE,
+ 	CC_LE,
+ 	CC_G
+-} x86_cc;
++};
+ 
+ enum {
+ 	SZ_B = 0,
+ 	SZ_W,
+ 	SZ_D,
+ 	SZ_Q
+-} x86_size;
++};
+ 
+ #ifdef X86_64
+ #define SZ_PTR SZ_Q
+@@ -85,7 +85,7 @@
+ 	MODE_REG_DIRECT = 0xC0,
+ //"phony" mode
+ 	MODE_IMMED = 0xFF
+-} x86_modes;
++};
+ 
+ void rol_ir(code_info *code, uint8_t val, uint8_t dst, uint8_t size);
+ void ror_ir(code_info *code, uint8_t val, uint8_t dst, uint8_t size);
+diff -r 7a6835c02db0 -r e45a317802bd vdp.h
+--- a/vdp.h	Sat Jul 11 21:04:16 2020 -0700
++++ b/vdp.h	Sat Jul 11 21:16:32 2020 -0700
+@@ -92,7 +92,7 @@
+ 	REG_DMASRC_L,
+ 	REG_DMASRC_M,
+ 	REG_DMASRC_H
+-} vdp_regs;
++};
+ 
+ //Mode reg 1
+ #define BIT_VSCRL_LOCK 0x80
+


### PR DESCRIPTION
This needed a backported patch from upstream to fix multiple-definition errors from the linker.

Seems to work fine, though I have not tested a gamepad.

![Capture d’écran de 2021-05-14 11-40-06](https://user-images.githubusercontent.com/86760/118259634-4d0b7000-b4a9-11eb-9a44-8a9590bf7ef4.png)

Fixes #2.

I prepared this in the belief that the 18.08 runtime is EOL. It doesn't actually seem to be, at least according to `flatpak info`, but maybe it was just overlooked? Anyway, I won't be offended by "no".

Upstream seems to have done a fair bit of development in the past couple of years but this snapshot is still the one linked on https://www.retrodev.com/blastem/.
