### PR TITLE
Move top-level comment after XML declaration

### DIFF
--- a/com.retrodev.blastem.appdata.xml
+++ b/com.retrodev.blastem.appdata.xml
@@ -1,5 +1,5 @@
-<!-- Copyright 2019 Bastien Nocera -->
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 Bastien Nocera -->
 <component type="desktop">
   <id>com.retrodev.blastem</id>
   <launchable type="desktop-id">com.retrodev.blastem.desktop</launchable>


### PR DESCRIPTION
xmllint (and Python's xml.etree) both pedantically complain about the
XML declaration not being at the start of the file:

    $ xmllint /var/lib/flatpak/exports/share/metainfo/com.retrodev.blastem.appdata.xml
    /var/lib/flatpak/exports/share/metainfo/com.retrodev.blastem.appdata.xml:2: parser error : XML declaration allowed only at the start of the document

Fix this by moving the comment one line lower.
