### PR TITLE
Update blastem to latest nightly

### DIFF
--- a/com.retrodev.blastem.appdata.xml
+++ b/com.retrodev.blastem.appdata.xml
@@ -27,6 +27,6 @@
   <translation/>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release date="2019-03-28" version="0.6.2"/>
+    <release date="2024-04-24" version="0.6.2+nightly-187bc857a76a"/>
   </releases>
 </component>

--- a/com.retrodev.blastem.appdata.xml
+++ b/com.retrodev.blastem.appdata.xml
@@ -18,13 +18,12 @@
   </description>
   <url type="homepage">https://www.retrodev.com/blastem/</url>
   <screenshots>
-    <screenshot type="default" width="640" height="517">https://raw.githubusercontent.com/flathub/com.retrodev.blastem/master/screenshots/blastem-1.png</screenshot>
-    <screenshot width="640" height="517">https://raw.githubusercontent.com/flathub/com.retrodev.blastem/master/screenshots/blastem-2.png</screenshot>
-    <screenshot width="640" height="517">https://raw.githubusercontent.com/flathub/com.retrodev.blastem/master/screenshots/blastem-3.png</screenshot>
+    <screenshot type="default" width="640" height="517"><image>https://raw.githubusercontent.com/flathub/com.retrodev.blastem/master/screenshots/blastem-1.png</image></screenshot>
+    <screenshot width="640" height="517"><image>https://raw.githubusercontent.com/flathub/com.retrodev.blastem/master/screenshots/blastem-2.png</image></screenshot>
+    <screenshot width="640" height="517"><image>https://raw.githubusercontent.com/flathub/com.retrodev.blastem/master/screenshots/blastem-3.png</image></screenshot>
   </screenshots>
   <update_contact>hadess@hadess.net</update_contact>
   <developer_name>Mike Pavone</developer_name>
-  <translation/>
   <content_rating type="oars-1.1"/>
   <releases>
     <release date="2024-04-24" version="0.6.2+nightly-187bc857a76a"/>

--- a/com.retrodev.blastem.json
+++ b/com.retrodev.blastem.json
@@ -28,7 +28,7 @@
                 "install -d /app/share/blastem/",
                 "cp -r shaders/ images/ gamecontrollerdb.txt rom.db /app/share/blastem/",
                 "install -m0644 -D default.cfg /app/etc/default.cfg",
-                "install -m0644 -D com.retrodev.blastem.png /app/share/icons/hicolor/256x256/com.retrodev.blastem.png",
+                "install -m0644 -D com.retrodev.blastem.png /app/share/icons/hicolor/256x256/apps/com.retrodev.blastem.png",
                 "install -m0644 -D com.retrodev.blastem.desktop /app/share/applications/com.retrodev.blastem.desktop",
                 "install -m0644 -D com.retrodev.blastem.appdata.xml /app/share/metainfo/com.retrodev.blastem.appdata.xml"
             ],

--- a/com.retrodev.blastem.json
+++ b/com.retrodev.blastem.json
@@ -28,7 +28,7 @@
                 "install -d /app/share/blastem/",
                 "cp -r shaders/ images/ gamecontrollerdb.txt rom.db /app/share/blastem/",
                 "install -m0644 -D default.cfg /app/etc/default.cfg",
-                "install -m0644 -D com.retrodev.blastem.png /app/share/icons/com.retrodev.blastem.png",
+                "install -m0644 -D com.retrodev.blastem.png /app/share/icons/hicolor/256x256/com.retrodev.blastem.png",
                 "install -m0644 -D com.retrodev.blastem.desktop /app/share/applications/com.retrodev.blastem.desktop",
                 "install -m0644 -D com.retrodev.blastem.appdata.xml /app/share/metainfo/com.retrodev.blastem.appdata.xml"
             ],

--- a/com.retrodev.blastem.json
+++ b/com.retrodev.blastem.json
@@ -35,8 +35,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://www.retrodev.com/repos/blastem/archive/0013362c320c.tar.bz2",
-                    "sha256" : "4e6a937097c868471507d59e4a5a6f0da8b06af44ee9f3d05d530c5348b2ad9b"
+                    "url" : "https://www.retrodev.com/repos/blastem/archive/187bc857a76a.tar.bz2",
+                    "sha256" : "a068b841b54d7b07bfb2a7e4c2c798a7e3556d3d654323f6ab725207572848fb"
                 },
                 {
                     "type" : "script",


### PR DESCRIPTION
The version that is currently being used is more than 2 years outdated and it's just another nightly release. I can't even open the System page under Settings and there's tons of issues with controller mapping on this version. These and tons of emulation accuracy fixes have been fixed over the time so I believe using the latest nightly is the best option.